### PR TITLE
fix: remediate edition-2 defects and restore deleted examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ AI Skill_*.md
 .claude/
 *.log
 scratch/
+
+# Agent guidance docs — kept local only. This skill is cloned into other
+# projects' skill folders, where a shipped AGENTS.md/CLAUDE.md would bleed
+# repo-development guidance into the consumer's agent context.
+AGENTS.md
+CLAUDE.md

--- a/SKILL.md
+++ b/SKILL.md
@@ -98,7 +98,7 @@ An AI drafting agent must never dilute true "terms of art"—expressions with an
 
 ### 9. Statutory Interpretation Canons
 * **Ejusdem Generis**: When a general word follows specific words in a list, interpret the general word in context of the specific ones (e.g., "cars, trucks, and other vehicles" - "other vehicles" limited to transportation).
-* **Noscitur a Sociis**: A word's meaning is informed by the words around it (e.g., in "banks, rivers, and streams," "bank" means a riverbank, not a financial institution, because its neighbors are bodies of water).
+* **Noscitur a Sociis**: A word's meaning is informed by the words around it (e.g., in "bank, river, and stream," "bank" means a riverbank, not a financial institution, because its neighbors are bodies of water).
 * **Expressio Unius Est Exclusio Alterius**: Mentioning specific items may imply exclusion of unmentioned ones - preserve intentional gaps.
 
 ---

--- a/SKILL.md
+++ b/SKILL.md
@@ -98,42 +98,42 @@ An AI drafting agent must never dilute true "terms of art"—expressions with an
 
 ### 9. Statutory Interpretation Canons
 * **Ejusdem Generis**: When a general word follows specific words in a list, interpret the general word in context of the specific ones (e.g., "cars, trucks, and other vehicles" - "other vehicles" limited to transportation).
-* **Noscitur a Sociis**: Words derive meaning from their linguistic neighbors (e.g., "bank, river, and stream" - all refer to financial institutions vs. bodies of water based on context).
+* **Noscitur a Sociis**: A word's meaning is informed by the words around it (e.g., in "banks, rivers, and streams," "bank" means a riverbank, not a financial institution, because its neighbors are bodies of water).
 * **Expressio Unius Est Exclusio Alterius**: Mentioning specific items may imply exclusion of unmentioned ones - preserve intentional gaps.
 
 ---
- 
- ## IV. Syntactic Pitfalls & Ambiguity Resolution
- 
- ### 10. Eradication of "Shall"
+
+## IV. Syntactic Pitfalls & Ambiguity Resolution
+
+### 10. Eradication of "Shall"
 * **Rule**: Complete eradication of the word "shall." Replace it based on the exact category of meaning:
   * **Obligation/Duty**: Use **must** (e.g., *"The Tenant must pay the rent"*).
   * **Future Action/Prediction**: Use **will** (e.g., *"The lease will terminate on Dec 31"*).
   * **Permission**: Use **may** (e.g., *"The Tenant may keep a pet"*).
   * **Status/Condition**: Use **is/are** (e.g., *"The contract price is [amount]"*).
 
-### 10. The Disjunctive/Conjunctive Paradox ("And/Or")
+### 11. The Disjunctive/Conjunctive Paradox ("And/Or")
 * **Rule**: Completely ban the phrase "and/or." Replace it with explicit logic:
   * **Inclusive**: Use *"A or B, or both"* (e.g., *"damages caused by negligence, willful misconduct, or both"*).
   * **Exclusive**: Use *"either A or B, but not both"*.
 
-### 11. Eradicating Provisos ("Provided That")
+### 12. Eradicating Provisos ("Provided That")
 * **Rule**: Ban "provided that" when used as a proviso (mid-sentence exception or afterthought). Allow at sentence beginning only as a condition introducer.
-* **Transformation**: 
+* **Transformation**:
   * For mid-sentence provisos: End previous sentence. Start new sentence with "But if" (exception) or "If" (condition).
   * For sentence-start conditions: Replace with "If [condition], [result]."
 
-### 12. Ambiguous Modifiers & The Last Antecedent
+### 13. Ambiguous Modifiers & The Last Antecedent
 * **Rule**: When a trailing modifier (e.g., *"incurred outside the state"*) is attached to a series of elements, it creates ambiguity.
 * **Resolution**:
   * If the modifier applies to the **entire series**, relocate it to the introductory clause (premodification) or format as a vertical, tabulated list.
   * If the modifier applies only to the **final item**, rephrase the sentence or place the item elsewhere to isolate it.
 
-### 13. Conversational Sentence Openers
+### 14. Conversational Sentence Openers
 * **Rule**: Avoid stuffy, multi-syllable transitions like *However, Furthermore, Moreover, Consequently, Therefore*.
 * **Alternative**: Use short, punchy, conversational conjunctions to begin sentences (*But, And, So, Yet*).
 
-### 14. Pronoun and Modifier Reference
+### 15. Pronoun and Modifier Reference
 * **Pronouns**: Replace *"such [noun]"* with *"this," "that," "these,"* or *"the"*. Replace *"the same"* as a pronoun with *"it"* or *"them"*.
 * **Singular They**: Acceptable for gender neutrality, but if it introduces ambiguity (multiple singular and plural entities), bypass it by repeating the specific noun.
 
@@ -141,12 +141,12 @@ An AI drafting agent must never dilute true "terms of art"—expressions with an
 
 ## V. Editorial Standards & Typography
 
-### 15. Typographic Design & Layout Rules (SEC Standards)
+### 16. Typographic Design & Layout Rules (SEC Standards)
 * **Font Selection**: Enforce Serif fonts (such as **Garamond**, **Palatino**, or **Georgia**) for extensive body text to improve tracking. Prohibit Times New Roman as a default. Use Sans Serif (such as **Arial** or **Calibri**) for headings.
 * **Margin Alignment**: Enforce Left-Aligned (Ragged Right). Prohibit fully justified text.
 * **Emphasis**: Prohibit all-caps and underlining for emphasis. Use bold styling sparingly (exception: conspicuous UCC warranty disclaimers).
 
-### 16. ABA Section of Litigation Punctuation & Style
+### 17. ABA Section of Litigation Punctuation & Style
 * **That vs. Which**: Use *"that"* (without a comma) for restrictive clauses; use *"which"* (always preceded by a comma) for nonrestrictive, parenthetical clauses.
 * **Quotation Punctuation**: Place commas and periods *inside* quotation marks. Place colons, semicolons, and footnote numbers *outside* quotation marks.
 * **Block Quotes**: For quotes containing 50 words or more, format as an indented, single-spaced block without surrounding quotation marks. Keep quotes under 50 words inline.
@@ -160,19 +160,19 @@ An AI drafting agent must never dilute true "terms of art"—expressions with an
 
 ## VI. Advanced Translation Logic
 
-### 17. Quantitative Readability Target
+### 18. Quantitative Readability Target
 * **Rule**: Strive to achieve a minimum Flesch Reading Ease score of **40** or higher on all public or consumer-facing texts.
 
-### 18. Numerical Consistency
+### 19. Numerical Consistency
 * **Rule**: Spell out numbers 1-9; use digits for 10+. In any single list or series, if one number is 10+ and rendered as digits, all numbers in that list must be digits.
- 
-### 19. Eradication of "Elegant Variation"
+
+### 20. Eradication of "Elegant Variation"
 * **Rule**: Maintain absolute terminological consistency. If a contract refers to a *"vehicle"* in one section, do not refer to it as an *"automobile"* or *"car"* in another. Locking vocabulary prevents accidental changes in legal meaning.
- 
-### 20. Dialogue Tag Relocation
+
+### 21. Dialogue Tag Relocation
 * **Rule**: In litigation briefs, avoid beginning multiple sentences with repetitive tags (e.g., *"The Plaintiff argues that..."*). Move the tag to the middle or end of the sentence (e.g., *"The statute is unambiguous, the Plaintiff asserts"*).
- 
-### 21. Civility and Professionalism (California Guidelines)
+
+### 22. Civility and Professionalism (California Guidelines)
 * **Rule**: Strip away aggressive, combative ad hominem attacks. Keep tone objective, respectful, and focused strictly on legal and factual arguments.
 
 ---

--- a/samples/comparison.md
+++ b/samples/comparison.md
@@ -137,7 +137,29 @@ This file provides real-world examples of traditional, complex legal text ("Befo
 
 ---
 
-## 12. Terms of Art Distinctions (When to Preserve)
+## 12. Syntactic Pitfalls & Ambiguities
+
+### A. Eradication of "Shall"
+* **Before**: The Buyer *shall* pay the purchase price upon closing. The Broker *shall* receive 3% commission, and the agreement *shall* be governed by New York law.
+* **After**: The Buyer *must* pay the purchase price upon closing. The Broker *will* receive a 3% commission, and the agreement *is* governed by New York law.
+* *Mechanics*: "Shall" is replaced with **must** for buyer's obligation, **will** for broker's future receipt, and **is** for the legal status of the governing law.
+
+### B. Resolving "And/Or"
+* **Before**: The Licensee is liable for any claims resulting from copyright infringement *and/or* trademark infringement.
+* **After**: The Licensee is liable for any claims resulting from copyright infringement, trademark infringement, *or both*.
+
+### C. Eradicating Provisos ("Provided That")
+* **Before**: The Seller will ship the goods within ten days, *provided that* if there is a severe weather event, the shipment may be delayed.
+* **After**: The Seller will ship the goods within ten days. *But if* there is a severe weather event, the shipment may be delayed.
+
+### D. Curing Trailing Modifiers
+* **Before**: The Employer will cover fees for educational seminars, certification courses, and industry conventions *held in the state of Texas*.
+* **After**: The Employer will cover the following expenses *if they are held in Texas*: (1) educational seminars, (2) certification courses, and (3) industry conventions.
+* *Mechanics*: Prevents ambiguity about whether "held in the state of Texas" applies to all three items or only to industry conventions.
+
+---
+
+## 13. Terms of Art Distinctions (When to Preserve)
 
 ### A. "Best Efforts" vs. "Reasonable Efforts"
 * **Before**: The Developer shall use its best efforts, reasonable efforts, and good faith to complete the project on time.
@@ -157,11 +179,11 @@ This file provides real-world examples of traditional, complex legal text ("Befo
 ### D. "Representations" vs. "Warranties"
 * **Before**: The Seller represents and warrants that the product conforms to specifications and will perform satisfactorily.
 * **After**: The Seller **represents** that the product conforms to the specifications attached. The Seller **warrants** that the product will perform satisfactorily for 90 days.
-* *Mechanics*: Representations are past/factual statements (truth at time of speaking). Warrantizations are promises for the future.
+* *Mechanics*: Representations are past or present factual statements (true when made). Warranties are promises about future performance.
 
 ---
 
-## 13. Semantic Divide: Terms of Art Preservation
+## 14. Semantic Divide: Terms of Art Preservation
 
 ### A. UCC Conspicuous Disclaimer
 * **Before**: The Seller makes no warranties that the products will pass without objection in the trade or are of average, acceptable quality.


### PR DESCRIPTION
## Description

Reviews and remediates the work in d0361b4 (*feat: add missing terms of art and statutory interpretation canons*). d0361b4 added genuinely useful content but shipped with structural defects and an unwarranted deletion.

### Kept (warranted content from d0361b4)
- Contract terms of art (time is of the essence, act of God, best/reasonable efforts, representations vs. warranties)
- Criminal-law terms of art (rule of lenity, strict liability, proximate cause)
- Statutory interpretation canons (ejusdem generis, noscitur a sociis, expressio unius)
- "Provided that" refinement (proviso vs. sentence-initial condition)
- Numerical-consistency rule; attorney-fees softening
- New terms-of-art before/after examples

### Fixed (defects introduced by d0361b4)
- **Duplicate section "10"** — both *Eradication of "Shall"* and *Disjunctive/Conjunctive Paradox* were numbered 10. Renumbered Sections IV–VI to a unique, sequential **10–22**.
- **Malformed markdown** — leading-space indentation on the `## IV` / `### 10` headers; trailing whitespace on 6 lines.
- **Incoherent canon example** — the *noscitur a sociis* example claimed "bank, river, and stream" all refer to financial institutions. Corrected.
- **Typo** — "Warrantizations" → "Warranties" in `comparison.md`.

### Restored (unwarranted deletion)
- d0361b4 **overwrote** `comparison.md` §12, deleting the *Shall / And-Or / Provisos / Trailing-Modifier* examples and calling them "redundant." Those rules still exist in `SKILL.md` and had no other examples, so coverage was lost. Restored as their own section; the new terms-of-art examples are kept alongside. Sections renumbered to 12 (Syntactic), 13 (Terms-of-Art Distinctions), 14 (Semantic Divide).

### Tooling
- `.gitignore`: exclude local agent guidance docs (`AGENTS.md`, `CLAUDE.md`). This skill is cloned into other projects' skill folders, where a shipped `AGENTS.md`/`CLAUDE.md` would bleed repo-development guidance into the consumer's agent context, so those files are kept local only.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an agent translation failure)
- [x] Rule refinement (polishes or clarifies an existing guideline)
- [x] Example addition (adds new before/after samples)

## Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] My rule changes have been added to SKILL.md.
- [x] I have provided corresponding before-and-after examples in samples/comparison.md.
- [x] I have verified that the new language preserves essential legal mechanisms and terms of art.
- [x] The text is gender-neutral and follows modern professional drafting standards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)