### PR TITLE
feat: require one audit-table row per section in Action Plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,15 @@ Tools without a skills system can still use these guidelines; load `SKILL.md` as
 Once installed, your AI agent will automatically detect and apply the skill when you ask it to edit legal documents, or you can invoke it explicitly:
 
 * **Explicit Prompting**:
-  > *"Review this contract clause using the `plain-legal-writing` skill."*
-  > *"Draft a brief response to this motion following the `plain-legal-writing` guidelines."*
+  > *"Review this contract clause using the `deslop` skill."*
+  > *"Draft a brief response to this motion following the `deslop` guidelines."*
 * **Slash Commands**:
   If your agent supports slash commands in its TUI, you can trigger it directly:
   ```text
   /deslop Audit this NDA agreement: [paste agreement text]
   ```
+
+* **What you get back**: an audit table with one row for each rule section (I–VI), so you can see what the agent checked, not only what it found. Sections with no violations say "none found," and the terms-of-art row lists what the agent kept verbatim. The rewrite follows the table.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -186,8 +186,10 @@ When asked to audit or rewrite legal text using this skill, perform the followin
    * Estimate the readability improvements (e.g., reducing word count, shortening sentences).
 
 2. **Contrast & Feedback**:
-   * Present a structured table or checklist showing the violations of plain English and editorial mechanics found in the text.
-   * Provide the rationale for why each violation hinders comprehension or breaches standard style.
+   * Present an audit table with **one row for every section (I–VI)**, in order. Do not omit a section. If a section has no violations, write **"none found"** in its row. The table must show what you *checked*, not only what you *found*.
+   * For section III, list the terms of art you kept verbatim (e.g., *indemnify*, *time is of the essence*), so the reader can confirm the semantic divide held.
+   * Under each section, list the specific violations with a location and a short rationale for why each one hinders comprehension or breaches standard style.
+   * Do not invent a violation to fill a row. "None found" is a correct, complete answer.
 
 3. **Plain English Revision**:
    * Provide the rewritten version of the text.


### PR DESCRIPTION
## **User description**
## Description

Step 2 of the Action Plan (`SKILL.md`, "Contrast & Feedback") asked for "a structured table showing the violations found." Because the rows were whatever the model happened to notice, a skipped rule section (say, IV: `shall`, `and/or`, provisos) left no trace: the table looked complete and the rewrite shipped with the violations still in it.

This change fixes the table's shape instead of adding detection rules:

- One row per section I–VI, in order, always present.
- "None found" is an explicit, valid entry, so there is no pressure to invent a violation to fill a row.
- Section III's row lists the terms of art kept verbatim, giving the semantic divide a place in the output for the first time.

No regex or grep steps were added on purpose. The skill runs on pasted text across Claude Code, Codex, and Antigravity, and legal text has many legitimate hits (`shall` in quoted statutes, `provided that` at sentence start per rule 12). Pattern matching would threaten the terms-of-art invariant; a required row only forces the model to look.

Affected: `SKILL.md` Action Plan, step 2 only. No directive changed, so `samples/comparison.md` is unchanged (this is a process change, not a before/after rule).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an agent translation failure)
- [ ] New style directive/rule (adds a new plain English guideline)
- [x] Rule refinement (polishes or clarifies an existing guideline)
- [ ] Example addition (adds new before/after samples)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] My rule changes have been added to [SKILL.md](SKILL.md).
- [ ] I have provided corresponding before-and-after examples in [samples/comparison.md](samples/comparison.md). (N/A: process step, no directive changed.)
- [x] I have verified that the new language preserves essential legal mechanisms and terms of art.
- [x] The text is gender-neutral and follows modern professional drafting standards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Require complete, transparent audit tables for legal text reviews

### What Changed
- Audit results now include one row for each section I–VI, in order, even when no violations are found
- Sections with no issues explicitly say “none found” instead of being omitted or padded with invented violations
- Section III records the legal terms of art kept unchanged, while each reported issue includes its location and a brief rationale

### Impact
`✅ Clearer audit coverage`
`✅ Fewer missed rule sections`
`✅ Safer preservation of legal terms`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
